### PR TITLE
Bug fix: run_intunecd_update() takes 1 positional argument

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ app.config.from_mapping(
         task_track_started=True,
     ),
 )
-app.config["APP_VERSION"] = "2.0.0"
+app.config["APP_VERSION"] = "2.0.1"
 app.config["APISPEC_SWAGGER_UI_URL"] = "/apidocs"
 app.config["APISPEC_TITLE"] = "IntuneCD Monitor API Docs"
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -839,7 +839,10 @@ def add_schedule():
     if tenant.new_branch == "true":
         schedule_tenant_args = [schedule_tenant, tenant.new_branch]
     else:
-        schedule_tenant_args = [schedule_tenant, ""]
+        if schedule_type == "update":
+            schedule_tenant_args = [schedule_tenant]
+        else:
+            schedule_tenant_args = [schedule_tenant, ""]
 
     add_scheduled_task(
         schedule_cron, schedule_name, schedule_task, schedule_tenant_args

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,6 +13,8 @@ services:
       - 8080
     environment:
       - TZ=Europe/Stockholm
+    volumes:
+      - ./db:/intunecd/db
 
   redis:
       image: "redis:6.0.5-buster"
@@ -27,6 +29,8 @@ services:
       - .env
     environment:
       - TZ=Europe/Stockholm
+    volumes:
+      - ./db:/intunecd/db
 
   beat:
     build: ./
@@ -38,6 +42,8 @@ services:
       - .env
     environment:
       - TZ=Europe/Stockholm
+    volumes:
+      - ./db:/intunecd/db
   
   nginx:
     build: ./nginx-dev


### PR DESCRIPTION
Bug fix where IntuneCD updates were not able to be kicked off by the schedule due to providing too many arguments to the update function.