### PR TITLE
v2.1.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ app.config.from_mapping(
         task_track_started=True,
     ),
 )
-app.config["APP_VERSION"] = "2.1.2"
+app.config["APP_VERSION"] = "2.1.3"
 app.config["APISPEC_SWAGGER_UI_URL"] = "/apidocs"
 app.config["APISPEC_TITLE"] = "IntuneCD Monitor API Docs"
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ app.config.from_mapping(
         task_track_started=True,
     ),
 )
-app.config["APP_VERSION"] = "2.1.0"
+app.config["APP_VERSION"] = "2.1.2"
 app.config["APISPEC_SWAGGER_UI_URL"] = "/apidocs"
 app.config["APISPEC_TITLE"] = "IntuneCD Monitor API Docs"
 

--- a/app/app_config.py
+++ b/app/app_config.py
@@ -88,6 +88,12 @@ if SESSION_LIFETIME_HOURS:
 else:
     PERMANENT_SESSION_LIFETIME = timedelta(hours=3)
 
+DOCUMENTATION_MAX_LENGTH = os.getenv("DOCUMENTATION_MAX_LENGTH")
+if DOCUMENTATION_MAX_LENGTH:
+    DOCUMENTATION_MAX_LENGTH = int(DOCUMENTATION_MAX_LENGTH)
+else:
+    DOCUMENTATION_MAX_LENGTH = None
+
 SQLALCHEMY_DATABASE_URI = "mssql+pyodbc:///?odbc_connect=%s" % params
 SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
 AUTHORITY = f"https://login.microsoftonline.com/{AZURE_TENANT_ID}"

--- a/app/run_intunecd.py
+++ b/app/run_intunecd.py
@@ -117,6 +117,7 @@ def create_documentation(PATH, TENANT) -> None:
         PATH (str): path to the repository
         TENANT (object): tenant object
     """
+
     cmd = [
         "IntuneCD-startdocumentation",
         "-c",
@@ -127,6 +128,10 @@ def create_documentation(PATH, TENANT) -> None:
         "-t",
         TENANT.name,
     ]
+
+    if app_config.DOCUMENTATION_MAX_LENGTH:
+        cmd += ["-m", app_config.DOCUMENTATION_MAX_LENGTH]
+
     cmd = " ".join(cmd)
 
     emit_message("Creating documentation...", "running", "backup", TENANT.id, socket)

--- a/app/run_intunecd.py
+++ b/app/run_intunecd.py
@@ -319,7 +319,7 @@ def run_intunecd_update(TENANT_ID) -> dict:
         }
 
 
-@shared_task(time_limit=3600, soft_time_limit=3000)
+@shared_task(time_limit=7200, soft_time_limit=6600)
 def run_intunecd_backup(TENANT_ID, NEW_BRANCH=None) -> dict:
     """Runs the IntuneCD-startbackup command for the specified tenant.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ h11==0.14.0
 idna==3.6
 Jinja2==3.1.3
 MarkupSafe==2.1.5
-msal==1.27.0
+msal==1.30.0
 pycparser==2.21
 PyJWT==2.8.0
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ Werkzeug==3.0.1
 wsproto==1.2.0
 python-dateutil==2.9.0.post0
 azure-storage-blob==12.19.0
-IntuneCD==2.3.3
+IntuneCD==2.3.6
 flask-migrate==4.0.7
 gitpython==3.1.42
 azure-identity==1.15.0


### PR DESCRIPTION
## Added
- A new environment variable, `DOCUMENTATION_MAX_LENGTH`, has been added to configure the max string length in the backup which can improve the time it takes to generate the HTML
## Updates
- IntuneCD has been bumped to 2.3.6
- Time out settings for backup has been changed to allow for larger environments to complete backup and documentation